### PR TITLE
Jwt-Authorization, Logout Endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,14 @@
 			<artifactId>mysql-connector-java</artifactId>
 			<version>8.0.13</version>
 		</dependency>
-    </dependencies>
+		<!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
 
+	</dependencies>
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/com/heroku/backend/CryptoHelper.java
+++ b/src/main/java/com/heroku/backend/CryptoHelper.java
@@ -34,13 +34,12 @@ public class CryptoHelper {
         }
         catch(NoSuchAlgorithmException e)
         {
-
+            e.printStackTrace();
         }
     }
 
     public String encryptString(String input){
         try{
-            SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
             KeySpec keySpec = new PBEKeySpec(key.toCharArray(), salt.getBytes(), 65536, 256);
             SecretKey tmp = secretKeyFactory.generateSecret(keySpec);
             SecretKeySpec secretKey = new SecretKeySpec(tmp.getEncoded(), "AES");
@@ -68,7 +67,6 @@ public class CryptoHelper {
 
     public String decryptString(String encryptedInput){
         try{
-            SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
             KeySpec keySpec = new PBEKeySpec(key.toCharArray(), salt.getBytes(), 65536, 256);
             SecretKey tmp = secretKeyFactory.generateSecret(keySpec);
             SecretKeySpec secretKey = new SecretKeySpec(tmp.getEncoded(), "AES");

--- a/src/main/java/com/heroku/backend/JwtAuthenticatedProfile.java
+++ b/src/main/java/com/heroku/backend/JwtAuthenticatedProfile.java
@@ -1,0 +1,52 @@
+package com.heroku.backend;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class JwtAuthenticatedProfile implements Authentication {
+
+    private final String username;
+
+    public JwtAuthenticatedProfile(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return username;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return username;
+    }
+}
+

--- a/src/main/java/com/heroku/backend/JwtAuthentication.java
+++ b/src/main/java/com/heroku/backend/JwtAuthentication.java
@@ -1,0 +1,50 @@
+package com.heroku.backend;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class JwtAuthentication implements Authentication {
+    private final String token;
+
+    public JwtAuthentication(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return token;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}
+

--- a/src/main/java/com/heroku/backend/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/heroku/backend/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.heroku.backend;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Serializable;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint, Serializable {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "You have no power here!");
+    }
+}

--- a/src/main/java/com/heroku/backend/JwtAuthenticationProvider.java
+++ b/src/main/java/com/heroku/backend/JwtAuthenticationProvider.java
@@ -1,0 +1,47 @@
+package com.heroku.backend;
+
+import com.heroku.backend.exceptions.JwtAuthenticationException;
+import com.heroku.backend.service.JwtTokenService;
+import io.jsonwebtoken.JwtException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+    private final JwtTokenService jwtService;
+
+    @SuppressWarnings("unused")
+    public JwtAuthenticationProvider() {
+        this(null);
+    }
+
+    @Autowired
+    public JwtAuthenticationProvider(JwtTokenService jwtService) {
+        this.jwtService = jwtService;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+        try {
+            String token = (String) authentication.getCredentials();
+            String username = jwtService.getUsernameFromToken(token);
+
+            return jwtService.validateToken(token)
+                    .map(aBoolean -> new JwtAuthenticatedProfile(username))
+                    .orElseThrow(() -> new JwtAuthenticationException("JWT Token validation failed"));
+
+        } catch (JwtException ex) {
+            System.out.println("Invalid JWT Token: " + ex.getMessage());
+            throw new JwtAuthenticationException("Failed to verify token");
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthentication.class.equals(authentication);
+    }
+}

--- a/src/main/java/com/heroku/backend/SecurityConfiguration.java
+++ b/src/main/java/com/heroku/backend/SecurityConfiguration.java
@@ -18,7 +18,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable()
-                .authorizeRequests().antMatchers("/register", "/user/checkEmail").authenticated()
+                .authorizeRequests().antMatchers("/register", "/user/checkEmail", "/login").authenticated()
                 .and()
                 .httpBasic();
     }

--- a/src/main/java/com/heroku/backend/SecurityConfiguration.java
+++ b/src/main/java/com/heroku/backend/SecurityConfiguration.java
@@ -1,26 +1,61 @@
 package com.heroku.backend;
 
+import com.heroku.backend.filter.JwtAuthenticationTokenFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Value("${basic_auth.username}")
     private String username;
     @Value("${basic_auth.password}")
     private String password;
 
+    private JwtAuthenticationEntryPoint unauthorizedHandler;
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    public SecurityConfiguration(JwtAuthenticationEntryPoint unauthorizedHandler, JwtAuthenticationProvider jwtAuthenticationProvider){
+        this.unauthorizedHandler = unauthorizedHandler;
+        this.jwtAuthenticationProvider = jwtAuthenticationProvider;
+    }
+
+    @Autowired
+    public void configureAuthentication(AuthenticationManagerBuilder authenticationManagerBuilder) {
+        authenticationManagerBuilder.authenticationProvider(jwtAuthenticationProvider);
+    }
+
+    @Bean
+    public JwtAuthenticationTokenFilter authenticationTokenFilterBean() {
+        return new JwtAuthenticationTokenFilter();
+    }
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        /*
         http.csrf().disable()
                 .authorizeRequests().antMatchers("/register", "/user/checkEmail", "/login").authenticated()
                 .and()
-                .httpBasic();
+                .httpBasic();*/
+
+        http.csrf().disable()
+                .exceptionHandling().authenticationEntryPoint(unauthorizedHandler).and()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+                .authorizeRequests()
+                .antMatchers("/user/logout", "/register").authenticated();
+
+        http.addFilterBefore(authenticationTokenFilterBean(), UsernamePasswordAuthenticationFilter.class);
+        http.headers().cacheControl();
     }
 
     @Autowired

--- a/src/main/java/com/heroku/backend/SecurityConfiguration.java
+++ b/src/main/java/com/heroku/backend/SecurityConfiguration.java
@@ -10,8 +10,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -42,17 +40,16 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        /*
         http.csrf().disable()
                 .authorizeRequests().antMatchers("/register", "/user/checkEmail", "/login").authenticated()
                 .and()
-                .httpBasic();*/
-
+                .httpBasic();
+        
         http.csrf().disable()
                 .exceptionHandling().authenticationEntryPoint(unauthorizedHandler).and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                 .authorizeRequests()
-                .antMatchers("/user/logout", "/register").authenticated();
+                .antMatchers("/user/logout").authenticated();
 
         http.addFilterBefore(authenticationTokenFilterBean(), UsernamePasswordAuthenticationFilter.class);
         http.headers().cacheControl();

--- a/src/main/java/com/heroku/backend/controller/LoginController.java
+++ b/src/main/java/com/heroku/backend/controller/LoginController.java
@@ -2,6 +2,7 @@ package com.heroku.backend.controller;
 
 import com.heroku.backend.data.LoginData;
 import com.heroku.backend.data.response.LoginResponseData;
+import com.heroku.backend.exceptions.LoggedInException;
 import com.heroku.backend.exceptions.MissingParameterException;
 import com.heroku.backend.exceptions.InvalidUserPassException;
 import com.heroku.backend.service.LoginService;
@@ -18,7 +19,8 @@ public class LoginController {
     public LoginController(LoginService loginService){ this.loginService = loginService; }
 
     @PostMapping("/login")
-    private ResponseEntity<LoginResponseData> login(@RequestBody LoginData loginData) throws MissingParameterException, InvalidUserPassException{
+    private ResponseEntity<LoginResponseData> login(@RequestBody LoginData loginData)
+            throws MissingParameterException, InvalidUserPassException, LoggedInException {
         return loginService.login(loginData);
     }
 

--- a/src/main/java/com/heroku/backend/controller/LoginController.java
+++ b/src/main/java/com/heroku/backend/controller/LoginController.java
@@ -19,7 +19,7 @@ public class LoginController {
     public LoginController(LoginService loginService){ this.loginService = loginService; }
 
     @PostMapping("/login")
-    private ResponseEntity<LoginResponseData> login(@RequestBody LoginData loginData)
+    public ResponseEntity<LoginResponseData> login(@RequestBody LoginData loginData)
             throws MissingParameterException, InvalidUserPassException, LoggedInException {
         return loginService.login(loginData);
     }

--- a/src/main/java/com/heroku/backend/controller/LogoutController.java
+++ b/src/main/java/com/heroku/backend/controller/LogoutController.java
@@ -1,0 +1,25 @@
+package com.heroku.backend.controller;
+
+import com.heroku.backend.data.LogoutData;
+import com.heroku.backend.data.response.LogoutResponse;
+import com.heroku.backend.exceptions.MissingParameterException;
+import com.heroku.backend.exceptions.UserNotLoggedInException;
+import com.heroku.backend.service.LogoutService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LogoutController {
+    private final LogoutService logoutService;
+
+    public LogoutController(LogoutService logoutService){
+        this.logoutService = logoutService;
+    }
+
+    @PostMapping("/user/logout")
+    public ResponseEntity<LogoutResponse> logout(@RequestBody LogoutData logoutData) throws MissingParameterException, UserNotLoggedInException {
+        return logoutService.logout(logoutData);
+    }
+}

--- a/src/main/java/com/heroku/backend/controller/LogoutController.java
+++ b/src/main/java/com/heroku/backend/controller/LogoutController.java
@@ -1,7 +1,7 @@
 package com.heroku.backend.controller;
 
 import com.heroku.backend.data.LogoutData;
-import com.heroku.backend.data.response.LogoutResponse;
+import com.heroku.backend.data.response.LogoutResponseData;
 import com.heroku.backend.exceptions.MissingParameterException;
 import com.heroku.backend.exceptions.UserNotLoggedInException;
 import com.heroku.backend.service.LogoutService;
@@ -19,7 +19,7 @@ public class LogoutController {
     }
 
     @PostMapping("/user/logout")
-    public ResponseEntity<LogoutResponse> logout(@RequestBody LogoutData logoutData) throws MissingParameterException, UserNotLoggedInException {
+    public ResponseEntity<LogoutResponseData> logout(@RequestBody LogoutData logoutData) throws MissingParameterException, UserNotLoggedInException {
         return logoutService.logout(logoutData);
     }
 }

--- a/src/main/java/com/heroku/backend/data/LoginData.java
+++ b/src/main/java/com/heroku/backend/data/LoginData.java
@@ -1,8 +1,10 @@
 package com.heroku.backend.data;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class LoginData {
     private String email;
     private String password;

--- a/src/main/java/com/heroku/backend/data/LoginData.java
+++ b/src/main/java/com/heroku/backend/data/LoginData.java
@@ -4,13 +4,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor
 public class LoginData {
     private String email;
     private String password;
-
-    public LoginData(String email, String password){
-        this.email = email;
-        this.password = password;
-    }
 }

--- a/src/main/java/com/heroku/backend/data/LogoutData.java
+++ b/src/main/java/com/heroku/backend/data/LogoutData.java
@@ -5,8 +5,4 @@ import lombok.Data;
 @Data
 public class LogoutData {
     private String username;
-
-    public LogoutData(String username){
-        this.username = username;
-    }
 }

--- a/src/main/java/com/heroku/backend/data/LogoutData.java
+++ b/src/main/java/com/heroku/backend/data/LogoutData.java
@@ -1,0 +1,12 @@
+package com.heroku.backend.data;
+
+import lombok.Data;
+
+@Data
+public class LogoutData {
+    private String username;
+
+    public LogoutData(String username){
+        this.username = username;
+    }
+}

--- a/src/main/java/com/heroku/backend/data/RegisterData.java
+++ b/src/main/java/com/heroku/backend/data/RegisterData.java
@@ -9,12 +9,4 @@ public class RegisterData {
     private String username;
     private String password;
     private AccountType accountType;
-
-    public RegisterData(String email, String username, String password, AccountType accountType)
-    {
-        this.email = email;
-        this.username = username;
-        this.password = password;
-        this.accountType = accountType;
-    }
 }

--- a/src/main/java/com/heroku/backend/data/response/LoginResponseData.java
+++ b/src/main/java/com/heroku/backend/data/response/LoginResponseData.java
@@ -11,9 +11,11 @@ public class LoginResponseData {
     private LocalDateTime localDateTime;
     private String username;
     private Status status;
+    private String accessToken;
 
-    public LoginResponseData(String username, LocalDateTime localDateTime){
+    public LoginResponseData(String username, String accessToken, LocalDateTime localDateTime){
         this.username = username;
+        this.accessToken = accessToken;
         this.localDateTime = localDateTime;
     }
 

--- a/src/main/java/com/heroku/backend/data/response/LogoutResponse.java
+++ b/src/main/java/com/heroku/backend/data/response/LogoutResponse.java
@@ -1,0 +1,17 @@
+package com.heroku.backend.data.response;
+
+import com.heroku.backend.enums.Status;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class LogoutResponse {
+    private Status status;
+    private LocalDateTime localDateTime;
+
+    public LogoutResponse(Status status, LocalDateTime localDateTime){
+        this.status = status;
+        this.localDateTime = localDateTime;
+    }
+}

--- a/src/main/java/com/heroku/backend/data/response/LogoutResponseData.java
+++ b/src/main/java/com/heroku/backend/data/response/LogoutResponseData.java
@@ -6,11 +6,11 @@ import lombok.Data;
 import java.time.LocalDateTime;
 
 @Data
-public class LogoutResponse {
+public class LogoutResponseData {
     private Status status;
     private LocalDateTime localDateTime;
 
-    public LogoutResponse(Status status, LocalDateTime localDateTime){
+    public LogoutResponseData(Status status, LocalDateTime localDateTime){
         this.status = status;
         this.localDateTime = localDateTime;
     }

--- a/src/main/java/com/heroku/backend/entity/UserEntity.java
+++ b/src/main/java/com/heroku/backend/entity/UserEntity.java
@@ -1,6 +1,7 @@
 package com.heroku.backend.entity;
 
 import com.heroku.backend.enums.AccountType;
+import com.heroku.backend.enums.ConnectionStatus;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -21,6 +22,7 @@ public class UserEntity {
     private String username;
     private String encryptedPassword;
     private AccountType accountType;
+    private ConnectionStatus connectionStatus;
 
     public UserEntity(String email, String username, String password, AccountType accountType) {
         this.email = email;
@@ -28,4 +30,9 @@ public class UserEntity {
         this.encryptedPassword = password;
         this.accountType = accountType;
     }
+
+    public void updateConnection(ConnectionStatus connectionStatus){
+        this.connectionStatus = connectionStatus;
+    }
+
 }

--- a/src/main/java/com/heroku/backend/enums/ConnectionStatus.java
+++ b/src/main/java/com/heroku/backend/enums/ConnectionStatus.java
@@ -1,0 +1,15 @@
+package com.heroku.backend.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ConnectionStatus {
+    LOGGED_IN("logged_in"),
+    LOGGED_OUT("logged_out");
+
+    private String connectionType;
+
+    ConnectionStatus(String accountType) {
+        this.connectionType = accountType;
+    }
+}

--- a/src/main/java/com/heroku/backend/exceptions/JwtAuthenticationException.java
+++ b/src/main/java/com/heroku/backend/exceptions/JwtAuthenticationException.java
@@ -1,0 +1,11 @@
+package com.heroku.backend.exceptions;
+
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationException extends AuthenticationException {
+    public JwtAuthenticationException(String msg) {
+        super(msg);
+    }
+}
+

--- a/src/main/java/com/heroku/backend/exceptions/LoggedInException.java
+++ b/src/main/java/com/heroku/backend/exceptions/LoggedInException.java
@@ -1,0 +1,11 @@
+package com.heroku.backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "User already logged in")
+public class LoggedInException extends Exception {
+    public LoggedInException(){
+        super();
+    }
+}

--- a/src/main/java/com/heroku/backend/exceptions/UserExistsException.java
+++ b/src/main/java/com/heroku/backend/exceptions/UserExistsException.java
@@ -1,6 +1,5 @@
 package com.heroku.backend.exceptions;
 
-
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 

--- a/src/main/java/com/heroku/backend/exceptions/UserNotLoggedInException.java
+++ b/src/main/java/com/heroku/backend/exceptions/UserNotLoggedInException.java
@@ -1,0 +1,11 @@
+package com.heroku.backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "User not logged in")
+public class UserNotLoggedInException extends Exception {
+    public UserNotLoggedInException(){
+        super();
+    }
+}

--- a/src/main/java/com/heroku/backend/filter/JwtAuthenticationTokenFilter.java
+++ b/src/main/java/com/heroku/backend/filter/JwtAuthenticationTokenFilter.java
@@ -1,0 +1,32 @@
+package com.heroku.backend.filter;
+
+import com.heroku.backend.JwtAuthentication;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationTokenFilter extends OncePerRequestFilter{
+
+    @Value("${jwt.header}")
+    private String tokenHeader;
+
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException{
+        final String requestHeader = request.getHeader(this.tokenHeader);
+
+        if(requestHeader != null && requestHeader.startsWith("Bearer ")){
+            String authToken = requestHeader.substring(7);
+            JwtAuthentication authentication = new JwtAuthentication(authToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/heroku/backend/service/JwtTokenService.java
+++ b/src/main/java/com/heroku/backend/service/JwtTokenService.java
@@ -1,5 +1,6 @@
 package com.heroku.backend.service;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
@@ -7,6 +8,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Optional;
+import java.util.function.Function;
 
 @Component
 public class JwtTokenService {
@@ -34,4 +37,34 @@ public class JwtTokenService {
     private Date calculateExpiration(Date createdDate){
         return new Date(createdDate.getTime() + expiration * 10000);
     }
+
+    public String getUsernameFromToken(String token) {
+        return getClaimFromToken(token, Claims::getSubject);
+    }
+
+    public Date getExpirationDateFromToken(String token) {
+        return getClaimFromToken(token, Claims::getExpiration);
+    }
+
+    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = getAllClaimsFromToken(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims getAllClaimsFromToken(String token) {
+        return Jwts.parser()
+                .setSigningKey(secret)
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Boolean isTokenNotExpired(String token) {
+        final Date expiration = getExpirationDateFromToken(token);
+        return expiration.after(new Date());
+    }
+
+    public Optional<Boolean> validateToken(String token) {
+        return  isTokenNotExpired(token) ? Optional.of(Boolean.TRUE) : Optional.empty();
+    }
+
 }

--- a/src/main/java/com/heroku/backend/service/JwtTokenService.java
+++ b/src/main/java/com/heroku/backend/service/JwtTokenService.java
@@ -1,0 +1,37 @@
+package com.heroku.backend.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.HashMap;
+
+@Component
+public class JwtTokenService {
+    private String secret;
+    private Long expiration;
+
+    public JwtTokenService(@Value("${jwt.secret}") String secret, @Value("${jwt.expiration}") Long expiration) {
+        this.secret = secret;
+        this.expiration = expiration;
+    }
+
+    public String generateToken(String username){
+        final Date createdDate = new Date();
+        final Date expirationTime = calculateExpiration(createdDate);
+
+        return Jwts.builder()
+                .setClaims(new HashMap<>())
+                .setSubject(username)
+                .setIssuedAt(createdDate)
+                .setExpiration(expirationTime)
+                .signWith(SignatureAlgorithm.HS256, secret)
+                .compact();
+    }
+
+    private Date calculateExpiration(Date createdDate){
+        return new Date(createdDate.getTime() + expiration * 10000);
+    }
+}

--- a/src/main/java/com/heroku/backend/service/LoginService.java
+++ b/src/main/java/com/heroku/backend/service/LoginService.java
@@ -1,14 +1,20 @@
 package com.heroku.backend.service;
 
 import com.heroku.backend.CryptoHelper;
+import com.heroku.backend.MongoDBConfiguration;
 import com.heroku.backend.data.LoginData;
 import com.heroku.backend.data.response.LoginResponseData;
 import com.heroku.backend.entity.UserEntity;
+import com.heroku.backend.enums.ConnectionStatus;
 import com.heroku.backend.enums.Status;
+import com.heroku.backend.exceptions.LoggedInException;
 import com.heroku.backend.exceptions.MissingParameterException;
 import com.heroku.backend.exceptions.InvalidUserPassException;
 import com.heroku.backend.repository.EmailRepository;
 import com.heroku.backend.repository.UsersRepository;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,14 +28,19 @@ public class LoginService {
     private EmailRepository emailRepository;
     private UsersRepository usersRepository;
     private CryptoHelper cryptoHelper;
+    private MongoOperations mongoOperations;
 
     public LoginService(EmailRepository emailRepository, UsersRepository usersRepository, CryptoHelper cryptoHelper){
         this.emailRepository = emailRepository;
         this.usersRepository = usersRepository;
         this.cryptoHelper = cryptoHelper;
+
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(MongoDBConfiguration.class);
+        mongoOperations = (MongoOperations) applicationContext.getBean("mongoTemplate");
     }
 
-    public ResponseEntity<LoginResponseData> login(@RequestBody LoginData loginData) throws MissingParameterException, InvalidUserPassException{
+    public ResponseEntity<LoginResponseData> login(@RequestBody LoginData loginData)
+            throws MissingParameterException, InvalidUserPassException, LoggedInException {
         String email = loginData.getEmail();
         String password = loginData.getPassword();
 
@@ -46,6 +57,12 @@ public class LoginService {
 
         if(!password.equals(decryptedPassword)){
             throw new InvalidUserPassException();}
+
+        if(foundUser.getConnectionStatus() == ConnectionStatus.LOGGED_IN)
+            throw new LoggedInException();
+
+        foundUser.updateConnection(ConnectionStatus.LOGGED_IN);
+        mongoOperations.save(foundUser);
 
         LoginResponseData loginResponse = new LoginResponseData(foundUser.getUsername(), LocalDateTime.now());
         loginResponse.setStatus(Status.SUCCESS);

--- a/src/main/java/com/heroku/backend/service/LoginService.java
+++ b/src/main/java/com/heroku/backend/service/LoginService.java
@@ -27,12 +27,14 @@ public class LoginService {
 
     private EmailRepository emailRepository;
     private UsersRepository usersRepository;
+    private JwtTokenService jwtTokenService;
     private CryptoHelper cryptoHelper;
     private MongoOperations mongoOperations;
 
-    public LoginService(EmailRepository emailRepository, UsersRepository usersRepository, CryptoHelper cryptoHelper){
+    public LoginService(EmailRepository emailRepository, UsersRepository usersRepository, JwtTokenService jwtTokenService, CryptoHelper cryptoHelper){
         this.emailRepository = emailRepository;
         this.usersRepository = usersRepository;
+        this.jwtTokenService = jwtTokenService;
         this.cryptoHelper = cryptoHelper;
 
         ApplicationContext applicationContext = new AnnotationConfigApplicationContext(MongoDBConfiguration.class);
@@ -64,7 +66,7 @@ public class LoginService {
         foundUser.updateConnection(ConnectionStatus.LOGGED_IN);
         mongoOperations.save(foundUser);
 
-        LoginResponseData loginResponse = new LoginResponseData(foundUser.getUsername(), LocalDateTime.now());
+        LoginResponseData loginResponse = new LoginResponseData(foundUser.getUsername(), jwtTokenService.generateToken(foundUser.getUsername()), LocalDateTime.now());
         loginResponse.setStatus(Status.SUCCESS);
 
         //ToDo: Add Auth-Token system per user, with refresh-token and expiry time

--- a/src/main/java/com/heroku/backend/service/LoginService.java
+++ b/src/main/java/com/heroku/backend/service/LoginService.java
@@ -29,7 +29,7 @@ public class LoginService {
         this.cryptoHelper = cryptoHelper;
     }
 
-    public ResponseEntity<LoginResponseData> login(@RequestBody LoginData loginData) throws MissingParameterException, InvalidUserPassException {
+    public ResponseEntity<LoginResponseData> login(@RequestBody LoginData loginData) throws MissingParameterException, InvalidUserPassException{
         String email = loginData.getEmail();
         String password = loginData.getPassword();
 

--- a/src/main/java/com/heroku/backend/service/LoginService.java
+++ b/src/main/java/com/heroku/backend/service/LoginService.java
@@ -69,7 +69,6 @@ public class LoginService {
         LoginResponseData loginResponse = new LoginResponseData(foundUser.getUsername(), jwtTokenService.generateToken(foundUser.getUsername()), LocalDateTime.now());
         loginResponse.setStatus(Status.SUCCESS);
 
-        //ToDo: Add Auth-Token system per user, with refresh-token and expiry time
         return ResponseEntity.ok(loginResponse);
     }
 

--- a/src/main/java/com/heroku/backend/service/LogoutService.java
+++ b/src/main/java/com/heroku/backend/service/LogoutService.java
@@ -2,7 +2,7 @@ package com.heroku.backend.service;
 
 import com.heroku.backend.MongoDBConfiguration;
 import com.heroku.backend.data.LogoutData;
-import com.heroku.backend.data.response.LogoutResponse;
+import com.heroku.backend.data.response.LogoutResponseData;
 import com.heroku.backend.entity.UserEntity;
 import com.heroku.backend.enums.ConnectionStatus;
 import com.heroku.backend.enums.Status;
@@ -29,7 +29,7 @@ public class LogoutService {
         mongoOperations = (MongoOperations) applicationContext.getBean("mongoTemplate");
     }
 
-    public ResponseEntity<LogoutResponse> logout(@RequestBody LogoutData logoutData) throws MissingParameterException, UserNotLoggedInException {
+    public ResponseEntity<LogoutResponseData> logout(@RequestBody LogoutData logoutData) throws MissingParameterException, UserNotLoggedInException {
         String username = logoutData.getUsername();
 
         if(username == null)
@@ -43,7 +43,7 @@ public class LogoutService {
         foundUser.updateConnection(ConnectionStatus.LOGGED_OUT);
         mongoOperations.save(foundUser);
 
-        LogoutResponse logoutResponse = new LogoutResponse(Status.SUCCESS, LocalDateTime.now());
-        return ResponseEntity.ok(logoutResponse);
+        LogoutResponseData logoutResponseData = new LogoutResponseData(Status.SUCCESS, LocalDateTime.now());
+        return ResponseEntity.ok(logoutResponseData);
     }
 }

--- a/src/main/java/com/heroku/backend/service/LogoutService.java
+++ b/src/main/java/com/heroku/backend/service/LogoutService.java
@@ -1,0 +1,49 @@
+package com.heroku.backend.service;
+
+import com.heroku.backend.MongoDBConfiguration;
+import com.heroku.backend.data.LogoutData;
+import com.heroku.backend.data.response.LogoutResponse;
+import com.heroku.backend.entity.UserEntity;
+import com.heroku.backend.enums.ConnectionStatus;
+import com.heroku.backend.enums.Status;
+import com.heroku.backend.exceptions.MissingParameterException;
+import com.heroku.backend.exceptions.UserNotLoggedInException;
+import com.heroku.backend.repository.UsersRepository;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.time.LocalDateTime;
+
+@Service
+public class LogoutService {
+    private UsersRepository usersRepository;
+    private MongoOperations mongoOperations;
+
+    public LogoutService(UsersRepository usersRepository){
+        this.usersRepository = usersRepository;
+        ApplicationContext applicationContext = new AnnotationConfigApplicationContext(MongoDBConfiguration.class);
+        mongoOperations = (MongoOperations) applicationContext.getBean("mongoTemplate");
+    }
+
+    public ResponseEntity<LogoutResponse> logout(@RequestBody LogoutData logoutData) throws MissingParameterException, UserNotLoggedInException {
+        String username = logoutData.getUsername();
+
+        if(username == null)
+            throw new MissingParameterException();
+
+        UserEntity foundUser = usersRepository.findByUsername(username);
+
+        if(foundUser.getConnectionStatus() == ConnectionStatus.LOGGED_OUT)
+            throw new UserNotLoggedInException();
+
+        foundUser.updateConnection(ConnectionStatus.LOGGED_OUT);
+        mongoOperations.save(foundUser);
+
+        LogoutResponse logoutResponse = new LogoutResponse(Status.SUCCESS, LocalDateTime.now());
+        return ResponseEntity.ok(logoutResponse);
+    }
+}

--- a/src/main/java/com/heroku/backend/service/RegisterService.java
+++ b/src/main/java/com/heroku/backend/service/RegisterService.java
@@ -12,7 +12,6 @@ import com.heroku.backend.exceptions.MissingParameterException;
 import com.heroku.backend.exceptions.UserExistsException;
 import com.heroku.backend.repository.EmailRepository;
 import com.heroku.backend.repository.UsersRepository;
-import jdk.nashorn.internal.runtime.regexp.joni.exception.InternalException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;

--- a/src/main/java/com/heroku/backend/service/RegisterService.java
+++ b/src/main/java/com/heroku/backend/service/RegisterService.java
@@ -7,6 +7,7 @@ import com.heroku.backend.data.response.RegisterResponseData;
 import com.heroku.backend.entity.EmailEntity;
 import com.heroku.backend.entity.UserEntity;
 import com.heroku.backend.enums.AccountType;
+import com.heroku.backend.enums.ConnectionStatus;
 import com.heroku.backend.enums.Status;
 import com.heroku.backend.exceptions.MissingParameterException;
 import com.heroku.backend.exceptions.UserExistsException;
@@ -58,7 +59,10 @@ public class RegisterService {
         RegisterResponseData responseData = new RegisterResponseData(LocalDateTime.now());
         responseData.setStatus(Status.SUCCESS);
 
-        usersRepository.insert(new UserEntity(email, username, encryptedPassword, accountType));
+        UserEntity newUser = new UserEntity(email, username, encryptedPassword, accountType);
+        newUser.updateConnection(ConnectionStatus.LOGGED_OUT);
+
+        usersRepository.insert(newUser);
         emailRepository.insert(new EmailEntity(email));
 
         return ResponseEntity.ok(responseData);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ basic_auth.username=${AUTH_USERNAME}
 basic_auth.password=${AUTH_PASSWORD}
 encryption.salt=${ENCRYPTION_SALT}
 encryption.key=${ENCRYPTION_KEY}
+jwt.secret = ${JWT_SECRET}
+jwt.expiration = ${JWT_EXPIRATION}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,4 @@ encryption.salt=${ENCRYPTION_SALT}
 encryption.key=${ENCRYPTION_KEY}
 jwt.secret = ${JWT_SECRET}
 jwt.expiration = ${JWT_EXPIRATION}
+jwt.header = ${JWT_HEADER}


### PR DESCRIPTION
With this commit there is a new security feature.
Each user will get a personalized access token when they login.

(Login response below)
```json
{
    "localDateTime": "2020-04-05T19:24:19.3582855",
    "username": "Logxn",
    "status": "SUCCESS",
"accessToken":"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJMb2d4biIsImV4cCI6MTU4NjE1NzQ1OSwiaWF0IjoxNTg2MTA3NDU5fQ.CQouaDDIXj5-uLDQGfSDYwwdzrqkr0HbnhttDt5ujIk"
}
```

This token is bound to a username so in the future when a endpoint is only supposed to be by a certain user or group we can decrypt this token to check if it matches the username or group-name.

The new access-token needs to be sent via a header currently named "X-REQUEST-TOKEN".
If this header is missing there will be a 401 Unauthorized message.

This new authentication method is now part of the /user/logout endpoint.

Here is a sample response if the user fails to provide the correct auth-token

```
{
    "timestamp": "2020-04-05T17:29:29.769+0000",
    "status": 401,
    "error": "Unauthorized",
    "message": "You have no power here!",
    "path": "/user/logout"
}
```

Basic auth still persists on the other endpoints.